### PR TITLE
fix: output es2015 to match TypeDoc 3.2 breaking changes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2015",
     "experimentalDecorators": true,
     "outDir": "./dist/"
   },


### PR DESCRIPTION
TypeDoc 3.2 includes breaking changes about TS output

Plugins now needs to output `es2015` to work in the last version of TypeDoc

See https://github.com/TypeStrong/typedoc/issues/943 for more details