### PR TITLE
Exclude reflections whose inherits cannot be resolved (react)

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -83,7 +83,7 @@ export class NoInheritPlugin extends ConverterComponent {
         // Look up the inheritance chain for a super that doesn't inherit this reflection
         if (resolvedInherit instanceof Reflection && this.isNoInheritUpHierarchy(context, reflection, resolvedInherit, 0)) {
           removals.push(reflection);
-        } else if (!resolvedInherit && reflection.parent instanceof DeclarationReflection && this.noInherit.indexOf(reflection.parent) > -1) {
+        } else if (!resolvedInherit && reflection.parent instanceof DeclarationReflection && this.noInherit.find(ignored => ignored.id === reflection.parent.id)) {
           removals.push(reflection);
         }
       });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -83,6 +83,8 @@ export class NoInheritPlugin extends ConverterComponent {
         // Look up the inheritance chain for a super that doesn't inherit this reflection
         if (resolvedInherit instanceof Reflection && this.isNoInheritUpHierarchy(context, reflection, resolvedInherit, 0)) {
           removals.push(reflection);
+        } else if (!resolvedInherit && reflection.parent instanceof DeclarationReflection && this.noInherit.indexOf(reflection.parent) > -1) {
+          removals.push(reflection);
         }
       });
 


### PR DESCRIPTION
This is primarily a workaround to make this plugin work with react.js component inheritance. When inheriting from React.Component (or PureComponent), the non-overridden react lifecycle methods had undefined reflections in their `inheritsFrom`, causing `resolvedInherit` to be undefined.

This change checks for an unresolved inherit, and that the parent is tagged with `@noInheritDoc`.

I was unable to figure out the root cause of why the lifecycle methods could not be resolved, so if that can be determined, a better change can be made.