### PR TITLE
fix: Support TypeDoc v0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -452,19 +452,13 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.18",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
-      "integrity": "sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==",
+      "version": "24.0.25",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.25.tgz",
+      "integrity": "sha512-hnP1WpjN4KbGEK4dLayul6lgtys6FPz0UfxMeMQCv0M+sTnzN3ConfiO72jHgLxl119guHgI8gLqDOrRLsyp2g==",
       "dev": true,
       "requires": {
-        "@types/jest-diff": "*"
+        "jest-diff": "^24.3.0"
       }
-    },
-    "@types/jest-diff": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
-      "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
-      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -473,9 +467,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
-      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -1614,7 +1608,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1635,12 +1630,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1655,17 +1652,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1782,7 +1782,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1794,6 +1795,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1808,6 +1810,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1815,12 +1818,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1839,6 +1844,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1919,7 +1925,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1931,6 +1938,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2016,7 +2024,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2052,6 +2061,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2071,6 +2081,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2114,12 +2125,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2192,9 +2205,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.1.tgz",
+      "integrity": "sha512-2dd6soo60cwKNJ90VewNLIzdZPR/E2YhszOTgHpN9V0YuwZk7x33/iZoIBnASwDFVHMY7iJ6NPL8d9f/DWYCTA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -2273,10 +2286,27 @@
       }
     },
     "highlight.js": {
-      "version": "9.15.10",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
-      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
-      "dev": true
+      "version": "9.17.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.17.1.tgz",
+      "integrity": "sha512-TA2/doAur5Ol8+iM3Ov7qy3jYcr/QiJ2eDTdRF4dfbjG7AaaB99J5G+zSl11ljbl6cIcahgPY6SKb3sC3EJ0fw==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.5.3"
+      },
+      "dependencies": {
+        "handlebars": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.1.tgz",
+          "integrity": "sha512-2dd6soo60cwKNJ90VewNLIzdZPR/E2YhszOTgHpN9V0YuwZk7x33/iZoIBnASwDFVHMY7iJ6NPL8d9f/DWYCTA==",
+          "dev": true,
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          }
+        }
+      }
     },
     "hosted-git-info": {
       "version": "2.8.4",
@@ -3255,6 +3285,12 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -3271,9 +3307,9 @@
       }
     },
     "lunr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
-      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
       "dev": true
     },
     "make-dir": {
@@ -3325,9 +3361,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==",
       "dev": true
     },
     "merge-stream": {
@@ -4602,15 +4638,16 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "24.0.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.0.2.tgz",
-      "integrity": "sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.3.0.tgz",
+      "integrity": "sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
         "buffer-from": "1.x",
         "fast-json-stable-stringify": "2.x",
         "json5": "2.x",
+        "lodash.memoize": "4.x",
         "make-error": "1.x",
         "mkdirp": "0.x",
         "resolve": "1.x",
@@ -4660,40 +4697,54 @@
       }
     },
     "typedoc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
-      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.16.1.tgz",
+      "integrity": "sha512-n2RdWDwUks7TvTND8bOWG8rC6cFxpo4o9fXlFNwRiGpc+N6Amb0c1v0Y5oqY2SX5rgIe7OftTkItPsbpJAuApg==",
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.3",
         "fs-extra": "^8.1.0",
-        "handlebars": "^4.1.2",
-        "highlight.js": "^9.15.8",
+        "handlebars": "^4.7.0",
+        "highlight.js": "^9.17.1",
         "lodash": "^4.17.15",
-        "marked": "^0.7.0",
+        "marked": "^0.8.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.0",
-        "typescript": "3.5.x"
+        "typedoc-default-themes": "^0.7.0",
+        "typescript": "3.7.x"
+      },
+      "dependencies": {
+        "handlebars": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.1.tgz",
+          "integrity": "sha512-2dd6soo60cwKNJ90VewNLIzdZPR/E2YhszOTgHpN9V0YuwZk7x33/iZoIBnASwDFVHMY7iJ6NPL8d9f/DWYCTA==",
+          "dev": true,
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          }
+        }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz",
-      "integrity": "sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.7.0.tgz",
+      "integrity": "sha512-yeD56oPXMKJ5nDiCZ27x/SIxx11646Gr5GscxtLSmrh3ucMX6Lklgo7cSABafQXlGPSN5Kb/oLxmfN33BeqMWw==",
       "dev": true,
       "requires": {
         "backbone": "^1.4.0",
         "jquery": "^3.4.1",
-        "lunr": "^2.3.6",
+        "lunr": "^2.3.8",
         "underscore": "^1.9.1"
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
       "dev": true
     },
     "uglify-js": {
@@ -4708,9 +4759,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
   },
   "author": "Jon Hardy",
   "peerDependencies": {
-    "typedoc": ">=0.10.0"
+    "typedoc": ">=0.16.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
-    "@types/node": "^12.7.2",
+    "@types/jest": "^24.0.25",
+    "@types/node": "^13.1.6",
     "fs-extra": "^8.1.0",
     "jest": "^24.8.0",
-    "ts-jest": "^24.0.2",
-    "typedoc": "^0.15.0",
-    "typescript": "3.5.x"
+    "ts-jest": "^24.3.0",
+    "typedoc": "^0.16.1",
+    "typescript": "3.7.x"
   },
   "files": [
     "dist"

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -86,7 +86,7 @@ export class NoInheritPlugin extends ConverterComponent {
       });
 
       removals.forEach((removal) => {
-        CommentPlugin.removeReflection(project, removal);
+        project.removeReflection(removal);
       });
     }
   }
@@ -163,10 +163,10 @@ export class NoInheritPlugin extends ConverterComponent {
   private resolveType(context: Context, reflection: Reflection, type: Type): Reflection {
     const project = context.project;
     if (type instanceof ReferenceType) {
-      if (type.symbolID === ReferenceType.SYMBOL_ID_RESOLVE_BY_NAME) {
+      if (type.symbolFullyQualifiedName === ReferenceType.SYMBOL_FQN_RESOLVE_BY_NAME) {
         return reflection.findReflectionByName(type.name);
-      } else if (!type.reflection && type.symbolID !== ReferenceType.SYMBOL_ID_RESOLVED) {
-        return project.reflections[project.symbolMapping[type.symbolID]];
+      } else if (!type.reflection && type.symbolFullyQualifiedName !== ReferenceType.SYMBOL_FQN_RESOLVED) {
+        return project.getReflectionFromFQN(type.symbolFullyQualifiedName);
       } else {
         return type.reflection;
       }

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -1,11 +1,15 @@
 import * as fs from 'fs-extra';
+import { join } from 'path';
+import { ModuleResolutionKind } from 'typescript';
 import { Application } from 'typedoc/dist/lib/application';
 
 const srcDir = 'test/src';
 const outDir = 'test/out';
 const specDir = 'test/specs';
-const app = new Application({
-  moduleResolution: 'node'
+const app = new Application();
+app.bootstrap({
+  moduleResolution: ModuleResolutionKind.NodeJs,
+  plugin: [join(__dirname, '..')]
 });
 
 describe(`Output typedoc documentation`, () => {

--- a/test/specs/basic.json
+++ b/test/specs/basic.json
@@ -1,8 +1,9 @@
 {
 	"id": 75,
-	"name": "typedoc-plugin-no-inherit",
+	"name": "typedoc-plugin-no-inherit - v1.1.10",
 	"kind": 0,
 	"flags": {},
+	"originalName": "",
 	"children": [
 		{
 			"id": 76,
@@ -19,7 +20,9 @@
 					"name": "Animal",
 					"kind": 128,
 					"kindString": "Class",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {
 						"shortText": "Documentation for the Animal class."
 					},
@@ -30,7 +33,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "The animal's name"
@@ -53,7 +57,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -61,7 +66,9 @@
 									"name": "move",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Move some distance."
 									},
@@ -71,7 +78,9 @@
 											"name": "distanceInMeters",
 											"kind": 32768,
 											"kindString": "Parameter",
-											"flags": {},
+											"flags": {
+												"isExported": true
+											},
 											"type": {
 												"type": "intrinsic",
 												"name": "number"
@@ -120,13 +129,13 @@
 					"extendedBy": [
 						{
 							"type": "reference",
-							"name": "Mammal",
-							"id": 82
+							"id": 82,
+							"name": "Mammal"
 						},
 						{
 							"type": "reference",
-							"name": "Reptile",
-							"id": 92
+							"id": 92,
+							"name": "Reptile"
 						}
 					]
 				},
@@ -135,7 +144,9 @@
 					"name": "Crocodile",
 					"kind": 128,
 					"kindString": "Class",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {
 						"shortText": "Docmentation for the Crocodile class."
 					},
@@ -146,7 +157,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -154,7 +166,9 @@
 									"name": "stealthAttack",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Surprise unsuspecting prey."
 									},
@@ -192,15 +206,15 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
-							"name": "Reptile",
-							"id": 92
+							"id": 92,
+							"name": "Reptile"
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
-							"name": "ColdBlooded",
-							"id": 133
+							"id": 133,
+							"name": "ColdBlooded"
 						}
 					]
 				},
@@ -209,7 +223,9 @@
 					"name": "Dog",
 					"kind": 128,
 					"kindString": "Class",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {
 						"shortText": "Documentation for the Dog class."
 					},
@@ -220,7 +236,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "The breed of the dog."
@@ -243,7 +260,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "The type of hair the mammal has."
@@ -261,8 +279,8 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"name": "Mammal.hairType",
-								"id": 83
+								"id": 83,
+								"name": "Mammal.hairType"
 							}
 						},
 						{
@@ -271,7 +289,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -279,7 +298,9 @@
 									"name": "bark",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Vocalize."
 									},
@@ -303,7 +324,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -311,20 +333,22 @@
 									"name": "generateHeat",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"type": {
 										"type": "intrinsic",
 										"name": "void"
 									},
 									"inheritedFrom": {
 										"type": "reference",
-										"name": "Mammal.generateHeat",
-										"id": 86
+										"id": 86,
+										"name": "Mammal.generateHeat"
 									},
 									"implementationOf": {
 										"type": "reference",
-										"name": "WarmBlooded.generateHeat",
-										"id": 130
+										"id": 130,
+										"name": "WarmBlooded.generateHeat"
 									}
 								}
 							],
@@ -337,13 +361,13 @@
 							],
 							"inheritedFrom": {
 								"type": "reference",
-								"name": "Mammal.generateHeat",
-								"id": 86
+								"id": 86,
+								"name": "Mammal.generateHeat"
 							},
 							"implementationOf": {
 								"type": "reference",
-								"name": "WarmBlooded.generateHeat",
-								"id": 129
+								"id": 129,
+								"name": "WarmBlooded.generateHeat"
 							}
 						},
 						{
@@ -352,7 +376,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -360,20 +385,22 @@
 									"name": "pumpBlood",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"type": {
 										"type": "intrinsic",
 										"name": "void"
 									},
 									"inheritedFrom": {
 										"type": "reference",
-										"name": "Mammal.pumpBlood",
-										"id": 84
+										"id": 84,
+										"name": "Mammal.pumpBlood"
 									},
 									"implementationOf": {
 										"type": "reference",
-										"name": "WarmBlooded.pumpBlood",
-										"id": 132
+										"id": 132,
+										"name": "WarmBlooded.pumpBlood"
 									}
 								}
 							],
@@ -386,13 +413,13 @@
 							],
 							"inheritedFrom": {
 								"type": "reference",
-								"name": "Mammal.pumpBlood",
-								"id": 84
+								"id": 84,
+								"name": "Mammal.pumpBlood"
 							},
 							"implementationOf": {
 								"type": "reference",
-								"name": "WarmBlooded.pumpBlood",
-								"id": 131
+								"id": 131,
+								"name": "WarmBlooded.pumpBlood"
 							}
 						}
 					],
@@ -425,15 +452,15 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
-							"name": "Mammal",
-							"id": 82
+							"id": 82,
+							"name": "Mammal"
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
-							"name": "WarmBlooded",
-							"id": 128
+							"id": 128,
+							"name": "WarmBlooded"
 						}
 					]
 				},
@@ -442,7 +469,9 @@
 					"name": "Mammal",
 					"kind": 128,
 					"kindString": "Class",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {
 						"shortText": "Documentation for the Mammal class."
 					},
@@ -453,7 +482,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "The type of hair the mammal has."
@@ -476,7 +506,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -484,15 +515,17 @@
 									"name": "generateHeat",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"type": {
 										"type": "intrinsic",
 										"name": "void"
 									},
 									"implementationOf": {
 										"type": "reference",
-										"name": "WarmBlooded.generateHeat",
-										"id": 130
+										"id": 130,
+										"name": "WarmBlooded.generateHeat"
 									}
 								}
 							],
@@ -505,8 +538,8 @@
 							],
 							"implementationOf": {
 								"type": "reference",
-								"name": "WarmBlooded.generateHeat",
-								"id": 129
+								"id": 129,
+								"name": "WarmBlooded.generateHeat"
 							}
 						},
 						{
@@ -515,7 +548,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -523,15 +557,17 @@
 									"name": "pumpBlood",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"type": {
 										"type": "intrinsic",
 										"name": "void"
 									},
 									"implementationOf": {
 										"type": "reference",
-										"name": "WarmBlooded.pumpBlood",
-										"id": 132
+										"id": 132,
+										"name": "WarmBlooded.pumpBlood"
 									}
 								}
 							],
@@ -544,8 +580,8 @@
 							],
 							"implementationOf": {
 								"type": "reference",
-								"name": "WarmBlooded.pumpBlood",
-								"id": 131
+								"id": 131,
+								"name": "WarmBlooded.pumpBlood"
 							}
 						}
 					],
@@ -576,22 +612,22 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
-							"name": "Animal",
-							"id": 77
+							"id": 77,
+							"name": "Animal"
 						}
 					],
 					"extendedBy": [
 						{
 							"type": "reference",
-							"name": "Dog",
-							"id": 101
+							"id": 101,
+							"name": "Dog"
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
-							"name": "WarmBlooded",
-							"id": 128
+							"id": 128,
+							"name": "WarmBlooded"
 						}
 					]
 				},
@@ -600,7 +636,9 @@
 					"name": "Reptile",
 					"kind": 128,
 					"kindString": "Class",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {
 						"shortText": "Documentation for the Reptile class."
 					},
@@ -611,7 +649,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "The animal's name"
@@ -629,8 +668,8 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"name": "Animal.name",
-								"id": 78
+								"id": 78,
+								"name": "Animal.name"
 							}
 						},
 						{
@@ -639,7 +678,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -647,7 +687,9 @@
 									"name": "absorbHeat",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Take in heat from the environment."
 									},
@@ -657,8 +699,8 @@
 									},
 									"implementationOf": {
 										"type": "reference",
-										"name": "ColdBlooded.absorbHeat",
-										"id": 135
+										"id": 135,
+										"name": "ColdBlooded.absorbHeat"
 									}
 								}
 							],
@@ -671,8 +713,8 @@
 							],
 							"implementationOf": {
 								"type": "reference",
-								"name": "ColdBlooded.absorbHeat",
-								"id": 134
+								"id": 134,
+								"name": "ColdBlooded.absorbHeat"
 							}
 						},
 						{
@@ -681,7 +723,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -689,7 +732,9 @@
 									"name": "move",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Move some distance."
 									},
@@ -699,7 +744,9 @@
 											"name": "distanceInMeters",
 											"kind": 32768,
 											"kindString": "Parameter",
-											"flags": {},
+											"flags": {
+												"isExported": true
+											},
 											"type": {
 												"type": "intrinsic",
 												"name": "number"
@@ -713,8 +760,8 @@
 									},
 									"inheritedFrom": {
 										"type": "reference",
-										"name": "Animal.move",
-										"id": 79
+										"id": 79,
+										"name": "Animal.move"
 									}
 								}
 							],
@@ -727,8 +774,8 @@
 							],
 							"inheritedFrom": {
 								"type": "reference",
-								"name": "Animal.move",
-								"id": 79
+								"id": 79,
+								"name": "Animal.move"
 							}
 						},
 						{
@@ -737,7 +784,8 @@
 							"kind": 2048,
 							"kindString": "Method",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"signatures": [
 								{
@@ -745,7 +793,9 @@
 									"name": "pumpBlood",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"type": {
 										"type": "intrinsic",
 										"name": "void"
@@ -789,22 +839,22 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
-							"name": "Animal",
-							"id": 77
+							"id": 77,
+							"name": "Animal"
 						}
 					],
 					"extendedBy": [
 						{
 							"type": "reference",
-							"name": "Crocodile",
-							"id": 114
+							"id": 114,
+							"name": "Crocodile"
 						}
 					],
 					"implementedTypes": [
 						{
 							"type": "reference",
-							"name": "ColdBlooded",
-							"id": 133
+							"id": 133,
+							"name": "ColdBlooded"
 						}
 					]
 				},
@@ -813,7 +863,9 @@
 					"name": "SubErrorA",
 					"kind": 128,
 					"kindString": "Class",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {
 						"shortText": "Docs for SubErrorA."
 					},
@@ -824,7 +876,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "propA docs"
@@ -847,11 +900,12 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isStatic": true
+								"isStatic": true,
+								"isExported": true
 							},
 							"sources": [
 								{
-									"fileName": "C:/Github/typedoc-plugin-no-inherit/node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "lib.es5.d.ts",
 									"line": 984,
 									"character": 17
 								}
@@ -859,7 +913,14 @@
 							"type": {
 								"type": "reference",
 								"name": "ErrorConstructor"
-							}
+							},
+							"extendedBy": [
+								{
+									"type": "reference",
+									"id": 138,
+									"name": "SubErrorA"
+								}
+							]
 						}
 					],
 					"groups": [
@@ -882,14 +943,15 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
+							"id": 143,
 							"name": "Error"
 						}
 					],
 					"extendedBy": [
 						{
 							"type": "reference",
-							"name": "SubErrorB",
-							"id": 144
+							"id": 144,
+							"name": "SubErrorB"
 						}
 					]
 				},
@@ -898,7 +960,9 @@
 					"name": "SubErrorB",
 					"kind": 128,
 					"kindString": "Class",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {
 						"shortText": "Docs for SubErrorB."
 					},
@@ -909,7 +973,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "propA docs"
@@ -927,8 +992,8 @@
 							},
 							"inheritedFrom": {
 								"type": "reference",
-								"name": "SubErrorA.propA",
-								"id": 139
+								"id": 139,
+								"name": "SubErrorA.propA"
 							}
 						},
 						{
@@ -937,7 +1002,8 @@
 							"kind": 1024,
 							"kindString": "Property",
 							"flags": {
-								"isPublic": true
+								"isPublic": true,
+								"isExported": true
 							},
 							"comment": {
 								"shortText": "propB docs"
@@ -975,8 +1041,8 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
-							"name": "SubErrorA",
-							"id": 138
+							"id": 138,
+							"name": "SubErrorA"
 						}
 					]
 				},
@@ -985,21 +1051,27 @@
 					"name": "Blooded",
 					"kind": 256,
 					"kindString": "Interface",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"children": [
 						{
 							"id": 126,
 							"name": "pumpBlood",
 							"kind": 2048,
 							"kindString": "Method",
-							"flags": {},
+							"flags": {
+								"isExported": true
+							},
 							"signatures": [
 								{
 									"id": 127,
 									"name": "pumpBlood",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Pump blood."
 									},
@@ -1037,13 +1109,13 @@
 					"extendedBy": [
 						{
 							"type": "reference",
-							"name": "WarmBlooded",
-							"id": 128
+							"id": 128,
+							"name": "WarmBlooded"
 						},
 						{
 							"type": "reference",
-							"name": "ColdBlooded",
-							"id": 133
+							"id": 133,
+							"name": "ColdBlooded"
 						}
 					]
 				},
@@ -1052,7 +1124,9 @@
 					"name": "ColdBlooded",
 					"kind": 256,
 					"kindString": "Interface",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"comment": {},
 					"children": [
 						{
@@ -1060,14 +1134,18 @@
 							"name": "absorbHeat",
 							"kind": 2048,
 							"kindString": "Method",
-							"flags": {},
+							"flags": {
+								"isExported": true
+							},
 							"signatures": [
 								{
 									"id": 135,
 									"name": "absorbHeat",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Take in heat from the environment."
 									},
@@ -1105,20 +1183,20 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
-							"name": "Blooded",
-							"id": 125
+							"id": 125,
+							"name": "Blooded"
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
-							"name": "Crocodile",
-							"id": 114
+							"id": 114,
+							"name": "Crocodile"
 						},
 						{
 							"type": "reference",
-							"name": "Reptile",
-							"id": 92
+							"id": 92,
+							"name": "Reptile"
 						}
 					]
 				},
@@ -1127,21 +1205,27 @@
 					"name": "WarmBlooded",
 					"kind": 256,
 					"kindString": "Interface",
-					"flags": {},
+					"flags": {
+						"isExported": true
+					},
 					"children": [
 						{
 							"id": 129,
 							"name": "generateHeat",
 							"kind": 2048,
 							"kindString": "Method",
-							"flags": {},
+							"flags": {
+								"isExported": true
+							},
 							"signatures": [
 								{
 									"id": 130,
 									"name": "generateHeat",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Generate heat to keep body temperature up."
 									},
@@ -1164,14 +1248,18 @@
 							"name": "pumpBlood",
 							"kind": 2048,
 							"kindString": "Method",
-							"flags": {},
+							"flags": {
+								"isExported": true
+							},
 							"signatures": [
 								{
 									"id": 132,
 									"name": "pumpBlood",
 									"kind": 4096,
 									"kindString": "Call signature",
-									"flags": {},
+									"flags": {
+										"isExported": true
+									},
 									"comment": {
 										"shortText": "Pump blood."
 									},
@@ -1181,8 +1269,8 @@
 									},
 									"inheritedFrom": {
 										"type": "reference",
-										"name": "Blooded.pumpBlood",
-										"id": 126
+										"id": 126,
+										"name": "Blooded.pumpBlood"
 									}
 								}
 							],
@@ -1195,8 +1283,8 @@
 							],
 							"inheritedFrom": {
 								"type": "reference",
-								"name": "Blooded.pumpBlood",
-								"id": 126
+								"id": 126,
+								"name": "Blooded.pumpBlood"
 							}
 						}
 					],
@@ -1220,20 +1308,20 @@
 					"extendedTypes": [
 						{
 							"type": "reference",
-							"name": "Blooded",
-							"id": 125
+							"id": 125,
+							"name": "Blooded"
 						}
 					],
 					"implementedBy": [
 						{
 							"type": "reference",
-							"name": "Dog",
-							"id": 101
+							"id": 101,
+							"name": "Dog"
 						},
 						{
 							"type": "reference",
-							"name": "Mammal",
-							"id": 82
+							"id": 82,
+							"name": "Mammal"
 						}
 					]
 				}


### PR DESCRIPTION
The public API has changed a bit, and TypeDoc does a better job of telling if something is exported or not now.

Updated dependencies to resolve vulnerabilities + allow TS to read the newer version of declaration files that TypeDoc's compilation emits.